### PR TITLE
Add new SKESA Dockerfile for the latest version

### DIFF
--- a/containers/SKESA/latest/Dockerfile
+++ b/containers/SKESA/latest/Dockerfile
@@ -1,0 +1,40 @@
+##### Base image ###############################################################
+
+FROM ralatsdio/biocontainers:v1.1.0
+
+##### Metadata #################################################################
+
+LABEL base.image="ralatsdio/biocontainers"
+LABEL version="1.1.0"
+LABEL software="SKESA"
+LABEL about.summary="Strategic Kmer Extension for Scrupulous Assemblies"
+LABEL about.home="https://github.com/ncbi/SKESA"
+LABEL about.license_file="https://github.com/ncbi/SKESA/blob/master/LICENSE"
+LABEL about.license="?"
+LABEL about.tags="Genomics"
+LABEL extra.identifiers.biotools="SKESA"
+LABEL extra.binaries="skesa"
+
+##### Installation #############################################################
+
+USER root
+ENV INSTALL_PFX=/home/biodocker
+
+# Install SKESA
+RUN cd $INSTALL_PFX && \
+    git clone https://github.com/ncbi/SKESA && \
+    cd SKESA && \
+    apt-get update && apt-get -y -qq install git build-essential bison libxml2 libboost-all-dev libz-dev && \
+    make 
+    # cp SKESA/skesa $INSTALL_PFX/bin/ && \
+    # chmod +x $INSTALL_PFX/bin/skesa
+
+##### Configuration ############################################################
+
+USER biodocker
+WORKDIR /data
+# CMD ['skesa']
+
+##### Maintainer ###############################################################
+
+MAINTAINER Raymond LeClair <raymond.leclair@springbok.io>


### PR DESCRIPTION
Currently, this Dockerfile doesn't compile. It's a close copy of [this](https://hub.docker.com/layers/ncbi/skesa/latest/images/sha256-165f8583242608bc4ecb522aa03b564fb1790f98b4419bb518b45e21255ef688) one, with the sole difference being that it compiles the latest version, not the stable version.

This is required to get `gfa_connector` in order to analyze arbitrary contains for which a GFA file was not produced.