### PR TITLE
Use centralized reusable workflows

### DIFF
--- a/.github/workflows/betterleaks.yaml
+++ b/.github/workflows/betterleaks.yaml
@@ -1,0 +1,6 @@
+---
+name: Betterleaks
+on: [pull_request, workflow_dispatch]
+jobs:
+  betterleaks:
+    uses: addgene/ops-github-actions/.github/workflows/betterleaks.yaml@18b4946e74b8541b6bacca4ff0988a90557e4267

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,6 @@
+---
+name: Semgrep
+on: [pull_request, workflow_dispatch]
+jobs:
+  semgrep:
+    uses: addgene/ops-github-actions/.github/workflows/semgrep.yaml@18b4946e74b8541b6bacca4ff0988a90557e4267

--- a/.github/workflows/stale-auto-branches.yaml
+++ b/.github/workflows/stale-auto-branches.yaml
@@ -1,0 +1,17 @@
+---
+name: Stale Auto Branches
+on:
+  schedule:
+    - cron: '0 6 * * 1-5'
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+jobs:
+  stale:
+    uses: addgene/ops-github-actions/.github/workflows/stale-branches.yaml@18b4946e74b8541b6bacca4ff0988a90557e4267
+    with:
+      days-before-stale: 1
+      days-before-delete: 2
+      stale-branch-label: 'stale auto branch 🗑️'
+      branches-filter-regex: '^(auto/|jenkins/|teamcity/)'

--- a/.github/workflows/stale-branches.yaml
+++ b/.github/workflows/stale-branches.yaml
@@ -1,0 +1,12 @@
+---
+name: Stale Branches
+on:
+  schedule:
+    - cron: '5 6 * * 1-5'
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+jobs:
+  stale:
+    uses: addgene/ops-github-actions/.github/workflows/stale-branches.yaml@18b4946e74b8541b6bacca4ff0988a90557e4267


### PR DESCRIPTION
## Summary

Replaces copy-pasted workflows with thin callers of the reusable workflows /
composite actions in addgene/ops-github-actions, pinned to a commit SHA
(Renovate keeps them current).

Adds fleet-wide Betterleaks (secrets; Gitleaks successor) and Semgrep (SAST)
callers. Those are informational today — not required status checks; red means
look at the log.

Behavior of existing checks is unchanged; logic and action pins now live in
one place.

## Test plan

- Ruff caller runs on this PR (if applicable) and passes under the check name `Ruff`.
- Betterleaks and Semgrep callers run on this PR.
- Scheduled stale sweeps only trigger from the default branch, so they are
  verified after merge.